### PR TITLE
feat: Add glowing effect to canvas nodes

### DIFF
--- a/src/components/canvas/AudioNodeComponent.tsx
+++ b/src/components/canvas/AudioNodeComponent.tsx
@@ -13,6 +13,7 @@ interface AudioNodeProps {
   onAddRecordingToNode: (nodeId: string, audioBlob: Blob, duration: number) => Promise<void>;
   onDeleteRecording: (nodeId: string, recordingId: string) => void;
   isConnected: boolean;
+  isGlowing?: boolean;
 }
 
 export const AudioNodeComponent: React.FC<AudioNodeProps> = ({
@@ -23,6 +24,7 @@ export const AudioNodeComponent: React.FC<AudioNodeProps> = ({
   onAddRecordingToNode,
   onDeleteRecording,
   isConnected,
+  isGlowing,
 }) => {
   const { isDarkMode } = useTheme();
   const [currentlyPlaying, setCurrentlyPlaying] = useState<string | null>(null);
@@ -102,7 +104,12 @@ export const AudioNodeComponent: React.FC<AudioNodeProps> = ({
       className={`absolute pointer-events-auto group ${
         isDarkMode ? 'text-white' : 'text-gray-900'
       }`}
-      style={{ left: node.x, top: node.y, transform: 'translate(-50%, -50%)' }}
+      style={{
+        left: node.x,
+        top: node.y,
+        transform: 'translate(-50%, -50%)',
+        boxShadow: isGlowing ? `0 0 20px 5px rgba(161, 161, 170, 0.7)` : 'none',
+      }}
       onPointerDown={handlePointerDown}
       data-node-id={node.id}
     >

--- a/src/components/canvas/CanvasArea.tsx
+++ b/src/components/canvas/CanvasArea.tsx
@@ -154,6 +154,7 @@ export const CanvasArea: React.FC<CanvasAreaProps> = ({
         connections={connectionsResult.connections}
         onAddRecordingToNode={audioNodesResult.addRecordingToNode}
         onDeleteRecording={audioNodesResult.deleteRecording}
+        nodeGlowResult={nodeGlowResult}
       />
     </div>
   );

--- a/src/components/canvas/ChatNodeComponent.tsx
+++ b/src/components/canvas/ChatNodeComponent.tsx
@@ -14,6 +14,7 @@ interface ChatNodeComponentProps {
   isSendingMessage: boolean;
   onResize: (nodeId: string, height: number) => void;
   isConnected: boolean;
+  isGlowing?: boolean;
 }
 
 export const ChatNodeComponent: React.FC<ChatNodeComponentProps> = ({ 
@@ -23,7 +24,8 @@ export const ChatNodeComponent: React.FC<ChatNodeComponentProps> = ({
   onSendMessage, 
   isSendingMessage, 
   onResize, 
-  isConnected 
+  isConnected,
+  isGlowing,
 }) => {
   const { isDarkMode } = useTheme();
   const scrollAreaViewportRef = useRef<HTMLDivElement>(null);
@@ -95,6 +97,7 @@ export const ChatNodeComponent: React.FC<ChatNodeComponentProps> = ({
         transform: 'translate(-50%, -50%)',
         width: '600px',
         height: `${node.height + 60}px`,
+        boxShadow: isGlowing ? '0 0 20px 5px rgba(168, 85, 247, 0.7)' : 'none',
       }}
       onPointerDown={handlePointerDown}
       data-node-id={node.id}

--- a/src/components/canvas/DocumentNodeComponent.tsx
+++ b/src/components/canvas/DocumentNodeComponent.tsx
@@ -12,9 +12,10 @@ interface DocumentNodeProps {
   onDeleteFile: (nodeId: string, fileId: string) => void;
   onUploadClick: (nodeId: string) => void;
   isConnected: boolean;
+  isGlowing?: boolean;
 }
 
-export const DocumentNodeComponent: React.FC<DocumentNodeProps> = ({ node, onPointerDown, onStartConnection, onDelete, onDeleteFile, onUploadClick, isConnected }) => {
+export const DocumentNodeComponent: React.FC<DocumentNodeProps> = ({ node, onPointerDown, onStartConnection, onDelete, onDeleteFile, onUploadClick, isConnected, isGlowing }) => {
   
   const handleNodePointerDown = (e: React.PointerEvent) => {
     const target = e.target as HTMLElement;
@@ -31,7 +32,12 @@ export const DocumentNodeComponent: React.FC<DocumentNodeProps> = ({ node, onPoi
     <div
       className="absolute cursor-move"
       data-node-id={node.id}
-      style={{ left: node.x, top: node.y, transform: 'translate(-50%, -50%)' }}
+      style={{
+        left: node.x,
+        top: node.y,
+        transform: 'translate(-50%, -50%)',
+        boxShadow: isGlowing ? '0 0 20px 5px rgba(59, 130, 246, 0.7)' : 'none',
+      }}
       onPointerDown={handleNodePointerDown}
     >
       <div className="group relative bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg shadow-lg w-72 border border-blue-200 hover:shadow-xl transition-shadow">

--- a/src/components/canvas/GroupNodeComponent.tsx
+++ b/src/components/canvas/GroupNodeComponent.tsx
@@ -12,6 +12,7 @@ interface GroupNodeProps {
   onDelete: (nodeId: string) => void;
   onUpdate: (nodeId: string, updates: Partial<Omit<GroupNode, 'id' | 'type'>>) => void;
   isConnected: boolean;
+  isGlowing?: boolean;
 }
 
 export const GroupNodeComponent: React.FC<GroupNodeProps> = ({
@@ -21,6 +22,7 @@ export const GroupNodeComponent: React.FC<GroupNodeProps> = ({
   onDelete,
   onUpdate,
   isConnected,
+  isGlowing,
 }) => {
   const { isDarkMode } = useTheme();
   const [isEditing, setIsEditing] = useState(false);
@@ -77,6 +79,7 @@ export const GroupNodeComponent: React.FC<GroupNodeProps> = ({
         transform: 'translate(-50%, -50%)',
         width: node.width,
         height: node.height,
+        boxShadow: isGlowing ? '0 0 20px 5px rgba(156, 163, 175, 0.7)' : 'none',
       }}
       onPointerDown={handlePointerDown}
       data-node-id={node.id}

--- a/src/components/canvas/ImageNodeComponent.tsx
+++ b/src/components/canvas/ImageNodeComponent.tsx
@@ -30,6 +30,7 @@ interface ImageNodeComponentProps {
   onUploadClick: (nodeId: string) => void;
   onAnalyzeImage: (nodeId: string, imageId: string, prompt?: string) => Promise<void>;
   isConnected: boolean;
+  isGlowing?: boolean;
 }
 
 export const ImageNodeComponent: React.FC<ImageNodeComponentProps> = ({
@@ -41,6 +42,7 @@ export const ImageNodeComponent: React.FC<ImageNodeComponentProps> = ({
   onUploadClick,
   onAnalyzeImage,
   isConnected,
+  isGlowing,
 }) => {
   const { isDarkMode } = useTheme();
   const [analyzingImageId, setAnalyzingImageId] = useState<string | null>(null);
@@ -92,7 +94,8 @@ export const ImageNodeComponent: React.FC<ImageNodeComponentProps> = ({
       style={{ 
         left: `${node.x}px`, 
         top: `${node.y}px`,
-        transform: 'translate(-50%, -50%)'
+        transform: 'translate(-50%, -50%)',
+        boxShadow: isGlowing ? '0 0 20px 5px rgba(99, 102, 241, 0.7)' : 'none',
       }}
       data-node-id={node.id}
     >

--- a/src/components/canvas/NodeLayer.tsx
+++ b/src/components/canvas/NodeLayer.tsx
@@ -50,6 +50,7 @@ interface NodeLayerProps {
   connections: Connection[];
   onAddRecordingToNode: (nodeId: string, audioBlob: Blob, duration: number) => Promise<void>;
   onDeleteRecording: (nodeId: string, recordingId: string) => void;
+  nodeGlowResult: ReturnType<typeof import('@/hooks/useNodeGlow').useNodeGlow>;
 }
 
 export const NodeLayer: React.FC<NodeLayerProps> = ({
@@ -92,6 +93,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
   connections,
   onAddRecordingToNode,
   onDeleteRecording,
+  nodeGlowResult,
 }) => {
   return (
     <>
@@ -107,6 +109,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
             onDelete={onDeleteGroupNode}
             onUpdate={onUpdateGroupNode}
             isConnected={isConnected}
+            isGlowing={nodeGlowResult.shouldShowGlow(node.id, 'group')}
           />
         );
       })}
@@ -123,6 +126,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
             onStartConnection={onStartConnection}
             onDelete={onDeleteVideoNode}
             isConnected={isConnected}
+            isGlowing={nodeGlowResult.shouldShowGlow(node.id, 'video')}
           />
         );
       })}
@@ -140,6 +144,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
             onDeleteFile={onDeleteDocumentFile}
             onUploadClick={onDocumentNodeUploadClick}
             isConnected={isConnected}
+            isGlowing={nodeGlowResult.shouldShowGlow(node.id, 'document')}
           />
         );
       })}
@@ -157,6 +162,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
             isSendingMessage={isSendingMessageNodeId === node.id}
             onResize={onChatNodeResize}
             isConnected={isConnected}
+            isGlowing={nodeGlowResult.shouldShowGlow(node.id, 'chat')}
           />
         );
       })}
@@ -173,6 +179,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
             onDelete={onDeleteTextNode}
             onUpdate={onUpdateTextNode}
             isConnected={isConnected}
+            isGlowing={nodeGlowResult.shouldShowGlow(node.id, 'text')}
           />
         );
       })}
@@ -188,6 +195,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
             onStartConnection={onStartConnection}
             onDelete={onDeleteWebsiteNode}
             isConnected={isConnected}
+            isGlowing={nodeGlowResult.shouldShowGlow(node.id, 'website')}
           />
         );
       })}
@@ -205,6 +213,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
             onAddRecordingToNode={onAddRecordingToNode}
             onDeleteRecording={onDeleteRecording}
             isConnected={isConnected}
+            isGlowing={nodeGlowResult.shouldShowGlow(node.id, 'audio')}
           />
         );
       })}
@@ -223,6 +232,7 @@ export const NodeLayer: React.FC<NodeLayerProps> = ({
             onUploadClick={onImageNodeUploadClick}
             onAnalyzeImage={onAnalyzeImage}
             isConnected={isConnected}
+            isGlowing={nodeGlowResult.shouldShowGlow(node.id, 'image')}
           />
         );
       })}

--- a/src/components/canvas/TextNodeComponent.tsx
+++ b/src/components/canvas/TextNodeComponent.tsx
@@ -15,6 +15,7 @@ interface TextNodeComponentProps {
   onDelete: (nodeId: string) => void;
   onStartConnection: (nodeId: string) => void;
   isConnected: boolean;
+  isGlowing?: boolean;
 }
 
 export const TextNodeComponent: React.FC<TextNodeComponentProps> = ({
@@ -24,6 +25,7 @@ export const TextNodeComponent: React.FC<TextNodeComponentProps> = ({
   onDelete,
   onStartConnection,
   isConnected,
+  isGlowing,
 }) => {
   const { isDarkMode } = useTheme();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -60,6 +62,7 @@ export const TextNodeComponent: React.FC<TextNodeComponentProps> = ({
             transform: `translate(${node.x}px, ${node.y}px)`,
             width: node.width,
             height: node.height,
+            boxShadow: isGlowing ? '0 0 20px 5px rgba(251, 146, 60, 0.7)' : 'none',
           }}
           onPointerDown={(e) => onPointerDown(e, node.id)}
         >

--- a/src/components/canvas/VideoNodeComponent.tsx
+++ b/src/components/canvas/VideoNodeComponent.tsx
@@ -11,6 +11,7 @@ interface VideoNodeProps {
   onStartConnection: (nodeId: string) => void;
   onDelete: (nodeId: string) => void;
   isConnected: boolean;
+  isGlowing?: boolean;
 }
 
 export const VideoNodeComponent: React.FC<VideoNodeProps> = ({
@@ -20,6 +21,7 @@ export const VideoNodeComponent: React.FC<VideoNodeProps> = ({
   onStartConnection,
   onDelete,
   isConnected,
+  isGlowing,
 }) => {
   const embedUrl = getYouTubeEmbedUrl(node.url);
 
@@ -64,7 +66,8 @@ export const VideoNodeComponent: React.FC<VideoNodeProps> = ({
       style={{
         left: node.x,
         top: node.y,
-        transform: 'translate(-50%, -50%)'
+        transform: 'translate(-50%, -50%)',
+        boxShadow: isGlowing ? '0 0 20px 5px rgba(239, 68, 68, 0.7)' : 'none',
       }}
       onPointerDown={handleNodePointerDown}
     >

--- a/src/components/canvas/WebsiteNodeComponent.tsx
+++ b/src/components/canvas/WebsiteNodeComponent.tsx
@@ -12,6 +12,7 @@ interface WebsiteNodeComponentProps {
   onStartConnection: (nodeId: string) => void;
   onDelete: (nodeId: string) => void;
   isConnected: boolean;
+  isGlowing?: boolean;
 }
 
 export const WebsiteNodeComponent: React.FC<WebsiteNodeComponentProps> = ({
@@ -20,6 +21,7 @@ export const WebsiteNodeComponent: React.FC<WebsiteNodeComponentProps> = ({
   onStartConnection,
   onDelete,
   isConnected,
+  isGlowing,
 }) => {
   const { isDarkMode } = useTheme();
   const [showTranscriptModal, setShowTranscriptModal] = useState(false);
@@ -38,7 +40,8 @@ export const WebsiteNodeComponent: React.FC<WebsiteNodeComponentProps> = ({
         style={{ 
           left: node.x, 
           top: node.y, 
-          transform: 'translate(-50%, -50%)' 
+          transform: 'translate(-50%, -50%)',
+          boxShadow: isGlowing ? '0 0 20px 5px rgba(16, 185, 129, 0.7)' : 'none',
         }}
         onPointerDown={(e) => onPointerDown(e, node.id)}
         data-node-id={node.id}


### PR DESCRIPTION
This commit introduces a glowing effect for nodes on the canvas.

The glowing effect is applied when a node is hovered over or selected. The color of the glow is specific to the node type, matching its existing color scheme.

The following changes were made:
- Modified all node components to accept an `isGlowing` prop and apply a conditional `boxShadow` style.
- Updated `CanvasArea.tsx` and `NodeLayer.tsx` to pass the `isGlowing` prop to each node component, based on the logic in the `useNodeGlow` hook.